### PR TITLE
support pagination in clients, with unit test.  basic fifo queue to avoid rate limiting

### DIFF
--- a/lib/services/Client.js
+++ b/lib/services/Client.js
@@ -6,9 +6,9 @@
 
 var utils = require('./utils');
 var defaultPagination = {
-  page: 1,
-  per_page: 25,
-  folder: 'active'
+    page: 1,
+    per_page: 25,
+    folder: 'active'
 };
 
 function ClientService(config) {
@@ -21,10 +21,10 @@ function ClientService(config) {
 }
 
 /* http://developers.freshbooks.com/docs/clients/#client.list */
-ClientService.prototype.list = function (filters, cb) { //cb(err, clients, metaData)
+ClientService.prototype.list = function(filters, cb) { //cb(err, clients, metaData)
     if (arguments.length == 1) {
-      cb = filters;
-      filters = defaultPagination;
+        cb = filters;
+        filters = defaultPagination;
     }
     var options = {
         method: 'client.list',
@@ -32,7 +32,7 @@ ClientService.prototype.list = function (filters, cb) { //cb(err, clients, metaD
         token: this.config.token
     };
 
-    utils.callAPI(filters, options, function (err, result) {
+    utils.callAPI(filters, options, function(err, result) {
         if (err) {
             cb(err, null);
         }

--- a/lib/services/Client.js
+++ b/lib/services/Client.js
@@ -5,6 +5,11 @@
  */
 
 var utils = require('./utils');
+var defaultPagination = {
+  page: 1,
+  per_page: 25,
+  folder: 'active'
+};
 
 function ClientService(config) {
 
@@ -16,22 +21,18 @@ function ClientService(config) {
 }
 
 /* http://developers.freshbooks.com/docs/clients/#client.list */
-ClientService.prototype.list = function(cb) { //cb(err, clients, metaData)
-
+ClientService.prototype.list = function (filters, cb) { //cb(err, clients, metaData)
+    if (arguments.length == 1) {
+      cb = filters;
+      filters = defaultPagination;
+    }
     var options = {
         method: 'client.list',
         url: this.config.url,
         token: this.config.token
     };
 
-    var filters;
-    if (typeof arguments[1] === 'function') {
-        cb = arguments[1];
-        filters = arguments[0];
-    }
-
-    utils.callAPI(null, options, function(err, result) {
-
+    utils.callAPI(filters, options, function (err, result) {
         if (err) {
             cb(err, null);
         }
@@ -134,7 +135,7 @@ ClientService.prototype.get = function(id, cb) { //cb(err, client)
         };
 
     utils.callAPI(data, options, function(err, result) {
-        
+
         if (err) {
             cb(err, null);
         }

--- a/lib/services/utils.js
+++ b/lib/services/utils.js
@@ -1,9 +1,48 @@
-
 var xml2js = require('xml2js'),
     request = require('request'),
     fs = require('fs');
 
+var fifoQueue = [];
+var payloadAway;
+
+function queueCallbackFinished() {
+    if (fifoQueue.length) {
+        fifoQueue.shift();
+    }
+    queueProcessNextRequest();
+}
+
+function queueProcessNextRequest() {
+    if (fifoQueue.length) {
+        var next = fifoQueue[0];
+        setTimeout(function() {
+            payloadAway = false;
+            callAPIDirectly(next.data, next.options, next.cb);
+            if (!payloadAway) {
+                queueCallbackFinished();//something broke, payload not launched
+            }
+        }, 0);
+    }
+}
+
 function callAPI(data, options, cb) {
+    //make a queue, so that rate limits don't lock us out
+    //rate are 15 completed requests per second
+    //simultaneous calls to Invoice.create fail with:
+    //"Invalid value for field 'number'. Unique value required, value provided was already used."
+    //therefore, need to fifoQueue requests
+    var queueItem = {
+        data: data,
+        options: options,
+        cb: cb
+    };
+    fifoQueue.push(queueItem);
+    if (fifoQueue.length == 1) {
+        queueProcessNextRequest();
+    }
+}
+
+function callAPIDirectly(data, options, cb) {
 
     if (!data) {
         data = {};
@@ -31,7 +70,7 @@ function callAPI(data, options, cb) {
     try {
         xmlStr = builder.buildObject(data);
     }
-    catch(e) {
+    catch (e) {
         cb(e, null);
         return;
     }
@@ -45,8 +84,8 @@ function callAPI(data, options, cb) {
         body: xmlStr
     };
 
-    var r = request.post(reqOpts, function(error, res, body) {
-
+    request.post(reqOpts, function(error, res, body) {
+        queueCallbackFinished();
         if (error) {
             cb(new Error("FreshBooks Request Error:" + error), null);
         }
@@ -54,7 +93,7 @@ function callAPI(data, options, cb) {
             cb(null, null);
         }
         else {
-            xml2js.parseString(body, { explicitArray: false }, function(error, result) {
+            xml2js.parseString(body, {explicitArray: false}, function(error, result) {
 
                 if (error) {
                     cb(error, null);
@@ -71,6 +110,7 @@ function callAPI(data, options, cb) {
             });
         }
     });
+    payloadAway = true;
 }
 
 exports.callAPI = callAPI;

--- a/test/Client.js
+++ b/test/Client.js
@@ -91,6 +91,25 @@ describe('Client', function() {
         });
     });
 
+    describe('list() with pagination', function () {
+        it('should list page 2 of client data', function (done) {
+            var pagination = {
+                page: 2,
+                per_page: 10,
+                folder: 'active'
+            };
+            fb.client.list(pagination, function (err, clients, metaData) {
+                if (!err) {
+                    assert.ok(Array.isArray(clients) && clients.length && clients[0].client_id, 'client.list should return a non-empty client array');
+                    assert.ok(metaData.page === "2");
+                    done(null);
+                } else {
+                   done(err);
+                }
+            });
+        });
+    });
+
     describe('delete()', function() {
         this.timeout(30000);
         it('should delete a client w/o error', function(done) {


### PR DESCRIPTION
Freshbooks limits api requests, so we can't just make them as fast as we would like.

http://www.freshbooks.com/developers
Request Limits
There are no limit on the number of API requests per day. However, requests will be rate-limited if too many calls are made within a short period of time. Additionally, a maximum of 100 results will be returned for list methods, regardless of the value sent with the per_page parameter.

On the phone, they said 15 completed requests per second.

Also we need pagination, if we have a large number of clients.
