### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ make test
 ### Complete FreshBooks API Documentation
 
 http://developers.freshbooks.com/
-
+Test on [RapidAPI](https://rapidapi.com/package/FreshbooksAPI/functions?utm_source=FreshbooksGitHub&utm_medium=button)
 
 
 ### Roadmap


### PR DESCRIPTION
I've added a link in your README to Freshbooks's functions page in RapidAPI. I've done this for a few Freshbooks SDKs to help those who are reading the READMEs, understand and test the API before use.